### PR TITLE
Added omission from the linkify trigger

### DIFF
--- a/worlds/plugins/CleftMUSH COD Handler.xml
+++ b/worlds/plugins/CleftMUSH COD Handler.xml
@@ -27,14 +27,6 @@ Multipurpose utility with sounds
 </plugin>
 <triggers>
   <trigger
-   enabled="y"
-   match="You think, &quot;*&quot;"
-   omit_from_output="y"
-   keep_evaluating="y"
-   sequence="100"
-  >
-  </trigger>
-  <trigger
    enabled="n"
    match="^kxwt\_waypoint$"
    omit_from_log="y"
@@ -52,6 +44,7 @@ musicPlaying = false
    enabled="y"
    group="linkify"
    match="^(?&lt;pre&gt;You think( to yourself| to say)?\,? (\&quot;|\')?)(?&lt;reply&gt;.*?)(?&lt;pst&gt;(\&quot;|\')?)$"
+   omit_from_output="y"
    regexp="y"
    script="hl_splitreply"
    send_to="14"


### PR DESCRIPTION
It was echoing the message twice, and we had a defunct trigger, both, so these things are punched up, now.